### PR TITLE
Change client secret property name, fixes selaias/strava#1

### DIFF
--- a/strava_configure.js
+++ b/strava_configure.js
@@ -6,6 +6,6 @@ Template.configureLoginServiceDialogForStrava.helpers({
 Template.configureLoginServiceDialogForStrava.fields = function () {
   return [
     {property: 'client_id', label: 'Client ID'},
-    {property: 'client_secret', label: 'Client Secret'}
+    {property: 'secret', label: 'Client Secret'}
   ];
 };


### PR DESCRIPTION
Updates `strava_configure.js`, as I see you use `secret` as the property name in your other Meteor OAuth packages.
